### PR TITLE
管理者専用API機能の実装

### DIFF
--- a/back/src/adapters/controller/admin/handler.go
+++ b/back/src/adapters/controller/admin/handler.go
@@ -1,0 +1,277 @@
+package admin
+
+import (
+	"errors"
+	"modules/src/config"
+	"modules/src/database/model"
+	"modules/src/datastructure/request"
+	"modules/src/datastructure/response"
+	"modules/src/module"
+	"modules/src/usecases"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+type AdminHandler struct {
+	UserUC     *usecases.UserUsecase
+	MovieUC    *usecases.MovieUsecase
+	PeriodUC   *usecases.PeriodUsecase
+	ScreeningUC *usecases.ScreeningUsecase
+}
+
+func NewAdminHandler(userUC *usecases.UserUsecase, movieUC *usecases.MovieUsecase, periodUC *usecases.PeriodUsecase, screeningUC *usecases.ScreeningUsecase) *AdminHandler {
+	return &AdminHandler{
+		UserUC:     userUC,
+		MovieUC:    movieUC,
+		PeriodUC:   periodUC,
+		ScreeningUC: screeningUC,
+	}
+}
+
+func (h *AdminHandler) Routes() module.Route {
+	return NewAdminRoutes(h)
+}
+
+// AdminLogin 管理者専用ログイン
+func (h *AdminHandler) AdminLogin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req request.AdminLoginRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   "入力形式が間違っています",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		// ユーザー検索
+		user, err := h.UserUC.UserRepo.FindByEmail(strings.ToLower(req.Email))
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"error": "メールアドレスまたはパスワードが間違っています",
+				})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "認証処理中にエラーが発生しました",
+			})
+			return
+		}
+
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "メールアドレスまたはパスワードが間違っています",
+			})
+			return
+		}
+
+		// 管理者権限チェック
+		isAdmin, err := h.UserUC.UserRepo.IsAdmin(user.ID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "管理者権限の確認中にエラーが発生しました",
+			})
+			return
+		}
+
+		if !isAdmin {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "管理者権限がありません",
+			})
+			return
+		}
+
+		// パスワード検証
+		err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password))
+		if err != nil {
+			if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"error": "メールアドレスまたはパスワードが間違っています",
+				})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "認証処理中にエラーが発生しました",
+			})
+			return
+		}
+
+		// JWTトークン生成
+		token, err := config.GenerateToken(user.ID, user.Email, user.Role.RoleName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "認証トークンの生成に失敗しました",
+			})
+			return
+		}
+
+		// ログイン成功レスポンス
+		c.JSON(http.StatusOK, response.AdminLoginResponse{
+			Message: "管理者ログイン成功",
+			Token:   token,
+			User: response.AdminUserResponse{
+				ID:             user.ID,
+				Name:           user.Name,
+				Email:          user.Email,
+				RoleName:       user.Role.RoleName,
+				PhoneNumber:    user.PhoneNumber,
+				CardNumber:     user.CardNumber,
+				CardExpiration: user.CardExpiration,
+				IsAdmin:        true,
+			},
+		})
+	}
+}
+
+// CreateMovie 管理者専用映画作成
+func (h *AdminHandler) CreateMovie() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req request.CreateMovieRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "入力形式が間違っています",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		// リクエストをモデルに変換
+		releaseDate, err := time.Parse("2006-01-02", req.ReleaseDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "公開日の形式が正しくありません",
+			})
+			return
+		}
+
+		// キャストを文字列に変換（DBでは文字列として保存）
+		castString := ""
+		if len(req.Cast) > 0 {
+			for i, actor := range req.Cast {
+				if i > 0 {
+					castString += ", "
+				}
+				castString += actor
+			}
+		}
+
+		movie := &model.Movie{
+			Title:       req.Title,
+			SubTitle:    req.SubTitle,
+			Description: req.Description,
+			ReleaseDate: releaseDate,
+			Genre:       req.Genre,
+			Director:    req.Director,
+			Cast:        castString,
+			Duration:    req.Duration,
+		}
+
+		// 映画を作成
+		if err := h.MovieUC.CreateMovie(movie); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "映画の作成に失敗しました",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{
+			"message": "映画が正常に作成されました",
+			"movie_id": movie.ID,
+		})
+	}
+}
+
+// CreateScreeningPeriod 管理者専用上映期間作成
+func (h *AdminHandler) CreateScreeningPeriod() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req request.PeriodRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "入力形式が間違っています",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		// 日付をパース
+		startDate, err := time.Parse("2006-01-02", req.StartDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "開始日の形式が正しくありません",
+			})
+			return
+		}
+
+		endDate, err := time.Parse("2006-01-02", req.EndDate)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "終了日の形式が正しくありません",
+			})
+			return
+		}
+
+		period := &model.ScreeningPeriod{
+			MovieID:   req.MovieID,
+			ScreenID:  req.ScreenID,
+			StartDate: startDate,
+			EndDate:   endDate,
+		}
+
+		// 上映期間を作成
+		if err := h.PeriodUC.CreatePeriod(period); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "上映期間の作成に失敗しました",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{
+			"message": "上映期間が正常に作成されました",
+			"period_id": period.ID,
+		})
+	}
+}
+
+// CreateScreening 管理者専用上映スケジュール作成
+func (h *AdminHandler) CreateScreening() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req request.CreateScreeningRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "入力形式が間違っています",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		screening := &model.Screening{
+			ScreeningPeriodID: req.ScreeningPeriodID,
+			Date:              req.Date,
+			StartTime:         req.StartTime,
+			Duration:          req.Duration,
+		}
+
+		// 上映スケジュールを作成
+		_, err := h.ScreeningUC.CreateScreening(screening)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "上映スケジュールの作成に失敗しました",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{
+			"message": "上映スケジュールが正常に作成されました",
+			"screening_id": screening.ID,
+		})
+	}
+}

--- a/back/src/adapters/controller/admin/route.go
+++ b/back/src/adapters/controller/admin/route.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"modules/src/middleware"
+	"modules/src/module"
+	"modules/src/repository"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AdminRouter struct {
+	handler  *AdminHandler
+	userRepo repository.UserRepository
+}
+
+func NewAdminRoutes(handler *AdminHandler) module.Route {
+	return &AdminRouter{
+		handler:  handler,
+		userRepo: handler.UserUC.UserRepo,
+	}
+}
+
+func (r *AdminRouter) RegisterRoutes(engine *gin.Engine) {
+	adminGroup := engine.Group("/admin")
+
+	// 管理者ログイン（認証不要）
+	adminGroup.POST("/login", r.handler.AdminLogin())
+
+	// 管理者専用エンドポイント（認証必要）
+	protected := adminGroup.Group("/")
+	protected.Use(middleware.AdminAuthMiddleware(r.userRepo))
+	{
+		protected.POST("/movies", r.handler.CreateMovie())
+		protected.POST("/screening-periods", r.handler.CreateScreeningPeriod())
+		protected.POST("/screenings", r.handler.CreateScreening())
+	}
+}

--- a/back/src/adapters/gateway/user_repository.go
+++ b/back/src/adapters/gateway/user_repository.go
@@ -23,7 +23,7 @@ func (r *GormUserRepository) Create(user *model.User) error {
 
 func (r *GormUserRepository) FindByEmail(email string) (*model.User, error) {
 	var user model.User
-	if err := r.DB.Where("email = ?", email).First(&user).Error; err != nil {
+	if err := r.DB.Preload("Role").Where("email = ?", email).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil
@@ -43,6 +43,15 @@ func (r *GormUserRepository) FindByID(id uint) (*model.User, error) {
 		return nil, err
 	}
 	return &user, nil
+}
+
+func (r *GormUserRepository) IsAdmin(userID uint) (bool, error) {
+	var count int64
+	err := r.DB.Table("admins").Where("user_id = ? AND deleted_at IS NULL", userID).Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func NewGormUserRepository(db *gorm.DB) *GormUserRepository {

--- a/back/src/config/jwt.go
+++ b/back/src/config/jwt.go
@@ -12,6 +12,11 @@ import (
 // !!! 本番環境では、環境変数から読み込むなど、より安全な方法で管理してください !!!
 var JWTSecret = []byte("your_super_secret_jwt_key_please_change_me")
 
+// GetJWTSecret はJWTの秘密鍵を返します
+func GetJWTSecret() string {
+	return string(JWTSecret)
+}
+
 // Claims はJWTのペイロードに含まれるカスタムクレームです
 type Claims struct {
 	UserID               uint   `json:"user_id"`

--- a/back/src/datastructure/request/admin.go
+++ b/back/src/datastructure/request/admin.go
@@ -1,0 +1,6 @@
+package request
+
+type AdminLoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8"`
+}

--- a/back/src/datastructure/response/admin.go
+++ b/back/src/datastructure/response/admin.go
@@ -1,0 +1,20 @@
+package response
+
+import "time"
+
+type AdminUserResponse struct {
+	ID             uint       `json:"id"`
+	Name           string     `json:"name"`
+	Email          string     `json:"email"`
+	RoleName       string     `json:"role"`
+	PhoneNumber    string     `json:"phone_number"`
+	CardNumber     string     `json:"card_number"`
+	CardExpiration *time.Time `json:"card_expiration"`
+	IsAdmin        bool       `json:"is_admin"`
+}
+
+type AdminLoginResponse struct {
+	Message string            `json:"message"`
+	Token   string            `json:"token"`
+	User    AdminUserResponse `json:"user"`
+}

--- a/back/src/di/handler.go
+++ b/back/src/di/handler.go
@@ -1,6 +1,7 @@
 package di
 
 import (
+	"modules/src/adapters/controller/admin"
 	"modules/src/adapters/controller/movie"
 	"modules/src/adapters/controller/period"
 	"modules/src/adapters/controller/purchase"
@@ -20,6 +21,7 @@ import (
 
 type Handlers struct {
 	User            *user.UserHandler
+	Admin           *admin.AdminHandler
 	Movie           *movie.MovieHandler
 	Screen          *screen.ScreenHandler
 	Seat            *seat.SeatHandler
@@ -77,8 +79,12 @@ func NewHandlers(db *gorm.DB, env config.Env) *Handlers {
 	reservationseatUsecase := usecases.NewReservationSeatUsecase(reservationseatRepo)
 	reservationseatHandler := reservationseat.NewReservationSeatHandler(reservationseatUsecase)
 
+	// Admin
+	adminHandler := admin.NewAdminHandler(userUC, movieUC, periodUC, screeningUC)
+
 	return &Handlers{
 		User:            userHandler,
+		Admin:           adminHandler,
 		Movie:           movieHandler,
 		Screen:          screenHandler,
 		Seat:            seatHandler,

--- a/back/src/middleware/admin_auth.go
+++ b/back/src/middleware/admin_auth.go
@@ -1,0 +1,99 @@
+package middleware
+
+import (
+	"modules/src/config"
+	"modules/src/repository"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func AdminAuthMiddleware(userRepo repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Authorization ヘッダーからトークンを取得
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "認証ヘッダーが見つかりません",
+			})
+			c.Abort()
+			return
+		}
+
+		// Bearer プレフィックスをチェック
+		tokenString := ""
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			tokenString = authHeader[7:] // "Bearer " を除去
+		} else {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "無効な認証形式です",
+			})
+			c.Abort()
+			return
+		}
+
+		// JWTトークンを検証
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			// 署名方式がHMACかどうかチェック
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, gin.Error{Err: jwt.ErrSignatureInvalid}
+			}
+			return []byte(config.GetJWTSecret()), nil
+		})
+
+		if err != nil || !token.Valid {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "無効なトークンです",
+			})
+			c.Abort()
+			return
+		}
+
+		// クレームからユーザー情報を取得
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "トークンクレームの解析に失敗しました",
+			})
+			c.Abort()
+			return
+		}
+
+		// ユーザーIDを取得
+		userID, ok := claims["user_id"].(float64)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "ユーザーIDが見つかりません",
+			})
+			c.Abort()
+			return
+		}
+
+		// 管理者権限チェック
+		isAdmin, err := userRepo.IsAdmin(uint(userID))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "管理者権限の確認中にエラーが発生しました",
+			})
+			c.Abort()
+			return
+		}
+
+		if !isAdmin {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "管理者権限が必要です",
+			})
+			c.Abort()
+			return
+		}
+
+		// ユーザー情報をコンテキストに設定
+		c.Set("userID", uint(userID))
+		c.Set("isAdmin", true)
+
+		// 次のハンドラーに進む
+		c.Next()
+	}
+}

--- a/back/src/repository/user_repository.go
+++ b/back/src/repository/user_repository.go
@@ -11,6 +11,7 @@ type UserRepository interface {
 	FindByID(id uint) (*model.User, error)
 	FindAll() ([]model.User, error)
 	Update(user *model.User) error
+	IsAdmin(userID uint) (bool, error)
 }
 
 type GormUserRepository struct {
@@ -52,4 +53,13 @@ func (r *GormUserRepository) FindAll() ([]model.User, error) {
 func (r *GormUserRepository) Update(user *model.User) error {
 	result := r.db.Save(user)
 	return result.Error
+}
+
+func (r *GormUserRepository) IsAdmin(userID uint) (bool, error) {
+	var count int64
+	err := r.db.Table("admins").Where("user_id = ? AND deleted_at IS NULL", userID).Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }


### PR DESCRIPTION
## 概要
映画館管理システムの管理者専用APIエンドポイントを実装しました。

## 主な変更内容
- 管理者専用ログイン機能
- JWT認証による管理者権限チェック機能
- 映画作成API
- 上映期間作成API  
- 上映スケジュール作成API

## 実装詳細
### 新規追加ファイル
- `src/adapters/controller/admin/handler.go` - 管理者APIハンドラー実装
- `src/adapters/controller/admin/route.go` - 管理者API用ルーティング設定
- `src/middleware/admin_auth.go` - 管理者認証ミドルウェア
- `src/datastructure/request/admin.go` - 管理者API用リクエスト構造体
- `src/datastructure/response/admin.go` - 管理者API用レスポンス構造体

### 変更ファイル
- `src/adapters/gateway/user_repository.go` - IsAdminメソッド追加
- `src/repository/user_repository.go` - IsAdminメソッドのインターフェース定義追加
- `src/di/handler.go` - 管理者ハンドラーの依存注入設定
- `src/config/jwt.go` - 管理者認証ミドルウェア用のJWT秘密鍵取得関数追加

## 実装済みAPIエンドポイント
- `POST /admin/login` - 管理者ログイン
- `POST /admin/movies` - 映画作成（要認証）
- `POST /admin/screening-periods` - 上映期間作成（要認証）
- `POST /admin/screenings` - 上映スケジュール作成（要認証）

## 動作確認
- 管理者ログインAPIの動作確認済み
- 映画作成、上映期間作成、上映スケジュール作成のAPIは実装済みだが動作確認は未実施