### PR TITLE
Screenが作られたタイミングでSeatが自動で生成されるようにしました

### DIFF
--- a/back/src/adapters/controller/seat/handler.go
+++ b/back/src/adapters/controller/seat/handler.go
@@ -133,3 +133,23 @@ func (h *SeatHandler) GetSeatByRowColumnScreenID() gin.HandlerFunc {
 		c.JSON(http.StatusOK, presenter.ToSeatResponse(*seat))
 	}
 }
+
+// スクリーンの最大行・列まで座席を一括生成
+func (h *SeatHandler) GenerateSeats() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		screenIDStr := c.Param("screen_id")
+		screenID, err := strconv.ParseUint(screenIDStr, 10, 32) // 10進数として解釈し、32bitに収まる値としてチェック
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "無効なスクリーンIDです"})
+			return
+		}
+
+		created, err := h.Usecase.GenerateSeatsByScreenID(uint(screenID)) // uint64にキャストしてます
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "座席の一括生成に失敗しました", "details": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{"created_count": created})
+	}
+}

--- a/back/src/adapters/controller/seat/route.go
+++ b/back/src/adapters/controller/seat/route.go
@@ -17,6 +17,7 @@ func (r *SeatRoutes) RegisterRoutes(engine *gin.Engine) {
 	{
 		seatGroup.GET("/find/:screen_id/:seatIdStr", r.Handler.GetSeatByRowColumnScreenID())
 		seatGroup.POST("/", r.Handler.CreateSeat())
+		seatGroup.POST("/generate/:screen_id", r.Handler.GenerateSeats())
 		seatGroup.GET("/", r.Handler.GetSeats())
 		seatGroup.GET("/by-screen/:screen_id", r.Handler.GetSeatsByScreenID())
 	}

--- a/back/src/database/model/scheme.go
+++ b/back/src/database/model/scheme.go
@@ -53,9 +53,9 @@ type Screen struct {
 
 type Seat struct {
 	gorm.Model
-	ScreenID uint   `gorm:"not null"`
-	Row      string `gorm:"not null"`
-	Column   int    `gorm:"not null"`
+	ScreenID uint   `gorm:"not null;uniqueIndex:idx_seat_screen_row_col"`
+	Row      string `gorm:"not null;uniqueIndex:idx_seat_screen_row_col"`
+	Column   int    `gorm:"not null;uniqueIndex:idx_seat_screen_row_col"`
 
 	Screen Screen `gorm:"foreignKey:ScreenID"`
 }

--- a/back/src/di/handler.go
+++ b/back/src/di/handler.go
@@ -49,14 +49,12 @@ func NewHandlers(db *gorm.DB, env config.Env) *Handlers {
 	movieUC := &usecases.MovieUsecase{MovieRepo: movieRepo}
 	movieHandler := movie.NewMovieHandler(movieUC, env.PosterStoragePath, env.FileServerBaseURL)
 
-	// Screen
+	// Screen & Seat
 	screenRepo := gateway.NewGormScreenRepository(db)
-	screenUC := &usecases.ScreenUsecase{ScreenRepo: screenRepo}
-	screenHandler := screen.NewScreenHandler(screenUC)
-
-	//Seat
 	seatRepo := gateway.NewGormSeatRepository(db)
-	seatUC := &usecases.SeatUsecase{SeatRepo: seatRepo}
+	seatUC := &usecases.SeatUsecase{SeatRepo: seatRepo, ScreenRepo: screenRepo}
+	screenUC := &usecases.ScreenUsecase{ScreenRepo: screenRepo}
+	screenHandler := screen.NewScreenHandler(screenUC, seatUC)
 	seatHandler := seat.NewSeatHandler(seatUC)
 
 	// screening

--- a/back/src/usecases/seat_usecase.go
+++ b/back/src/usecases/seat_usecase.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"modules/src/database/model"
 	"modules/src/repository" // SeatRepository インターフェースのパス
+	"strings"
 )
 
 type SeatUsecase struct {
-	SeatRepo repository.SeatRepository
+	SeatRepo   repository.SeatRepository
+	ScreenRepo repository.ScreenRepository
 }
 
 func (uc *SeatUsecase) CreateSeat(seat *model.Seat) error {
@@ -29,4 +31,41 @@ func (uc *SeatUsecase) GetSeatByRowColumnScreenID(row string, column int, screen
 		return nil, fmt.Errorf("座席情報(行: %s, 列: %d, スクリーンID: %d) の取得に失敗しました: %w", row, column, screenID, err)
 	}
 	return seat, nil // 取得した座席を返す
+}
+
+// スクリーンの最大行・列までまとめて座席を生成する
+func (uc *SeatUsecase) GenerateSeatsByScreenID(screenID uint) (int, error) {
+	screen, err := uc.ScreenRepo.FindByID(screenID)
+	if err != nil {
+		return 0, fmt.Errorf("スクリーン情報の取得に失敗しました: %w", err)
+	}
+
+	maxRow := strings.TrimSpace(screen.MaxRow)
+	if maxRow == "" {
+		return 0, fmt.Errorf("スクリーンに最大行が設定されていません")
+	}
+	// rune は1文字（Unicodeコードポイント）を表す整数型
+	rowRune := []rune(strings.ToUpper(maxRow))[0]
+	if rowRune < 'A' || rowRune > 'Z' {
+		return 0, fmt.Errorf("最大行の指定が不正です: %s", maxRow)
+	}
+
+	created := 0
+	for r := 'A'; r <= rowRune; r++ {
+		for c := 1; c <= screen.MaxColumn; c++ {
+			existing, err := uc.SeatRepo.GetSeatByRowColumnScreenID(string(r), c, screenID)
+			if err != nil {
+				return created, fmt.Errorf("既存座席確認に失敗しました: %w", err)
+			}
+			if existing != nil {
+				continue
+			}
+			if err := uc.SeatRepo.Create(&model.Seat{ScreenID: screenID, Row: string(r), Column: c}); err != nil {
+				return created, fmt.Errorf("座席作成に失敗しました: %w", err)
+			}
+			created++
+		}
+	}
+
+	return created, nil
 }

--- a/front/src/app/admin/seats/page.tsx
+++ b/front/src/app/admin/seats/page.tsx
@@ -47,10 +47,18 @@ export default function ScreenCreatePage() {
       })
       if (!res.ok) {
         const errText = await res.text()
-        throw new Error(errText || "スクリーン登録に失敗しました")
+        setScreenError(errText || "スクリーン登録に失敗しました")
+        return
       }
       const created = await res.json()
-      setScreenStatus(`スクリーン${created?.id ?? ""}を登録しました`)
+      const screen = created?.screen
+      const createdSeats = created?.created_seats
+      const message =
+        created?.message ??
+        (screen?.id
+          ? `スクリーン${screen.id}を登録し、座席を${createdSeats ?? 0}件生成しました`
+          : "スクリーンを登録しました")
+      setScreenStatus(message)
     } catch (error) {
       setScreenError(error instanceof Error ? error.message : "スクリーン登録に失敗しました")
     } finally {


### PR DESCRIPTION
## やったこと
Screenが作られたタイミングでSeatが自動で生成されるようにしました

## 背景
seatを1座席ずつエンドポイントを叩いて生成させてきた←手間！！！

## 対象Issue
https://github.com/HALcinema-IAIHIW/movie-manager/issues/144

## 補足
1.今まではseat単体を手動で1シートずつ生成してきましたが、このPRでScreenを生成したタイミングでAからMAX列までと1行目からMAX行目までを一括生成されます。
<img width="265" height="174" alt="スクリーンショット 2025-12-09 0 04 16" src="https://github.com/user-attachments/assets/8710419c-c649-45b3-8846-152585893968" />

2.UI側からの検証で、データが生成されているのを確認しました
<img width="1493" height="886" alt="スクリーンショット 2025-12-08 23 49 17" src="https://github.com/user-attachments/assets/2117187b-63b3-4c2a-b701-444667b8761c" />
<img width="1242" height="832" alt="スクリーンショット 2025-12-08 23 49 33" src="https://github.com/user-attachments/assets/594c71f1-a629-4a2b-ab1f-209cfb6f215f" />
<img width="1254" height="837" alt="スクリーンショット 2025-12-08 23 49 52" src="https://github.com/user-attachments/assets/e76e2a67-6d3f-4a90-a383-bb45a9f0eb8d" />

3. seatをcreateするpost通信のエンドポイントのレスポンス変更
以前は`screen_id`と`screen_column`と`screen_rows`のみでしたが、`created_seats`を追加して、座席数を含めるようにしました。
→Admin画面のScreen生成ページで、いくつ作られたかを表示させるため

<img width="1247" height="735" alt="スクリーンショット 2025-12-09 0 12 17" src="https://github.com/user-attachments/assets/806a3811-a173-4c7e-bdcd-8a5a1f02b7b3" />
<img width="1493" height="886" alt="スクリーンショット 2025-12-08 23 49 17" src="https://github.com/user-attachments/assets/48fa4241-e50f-4ad9-b4e5-8ddae7fd969f" />

